### PR TITLE
Add quickfix listing and improve conflict handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ A Neovim plugin that helps you quickly **navigate and resolve merge conflicts** 
      register_keymaps = false, -- Disable internal keymaps if using lazy.nvim keys
   },
   keys = {
-    { "]g", ":HeadhunterNext", desc = "Go to next Conflict" },
-    { "[g", ":HeadhunterPrevious", desc = "Go to previous Conflict" },
-    { "<leader>gh", ":HeadhunterTakeHead", desc = "Take changes from HEAD" },
-    { "<leader>go", ":HeadhunterTakeOrigin", desc = "Take changes from origin" },
-    { "<leader>gb", ":HeadhunterTakeBoth", desc = "Take both changes" },
+    { "]g", "<cmd>HeadhunterNext<cr>", desc = "Go to next Conflict" },
+    { "[g", "<cmd>HeadhunterPrevious<cr>", desc = "Go to previous Conflict" },
+    { "<leader>gh", "<cmd>HeadhunterTakeHead<cr>", desc = "Take changes from HEAD" },
+    { "<leader>go", "<cmd>HeadhunterTakeOrigin<cr>", desc = "Take changes from origin" },
+    { "<leader>gb", "<cmd>HeadhunterTakeBoth<cr>", desc = "Take both changes" },
   },
 }
 ```

--- a/lua/headhunter/init.lua
+++ b/lua/headhunter/init.lua
@@ -4,267 +4,287 @@ local conflicts = {}
 local current_index = 0
 
 local defaultConfig = {
-    register_keymaps = true,
-    keymaps = {
-        prev_conflict = "[g",
-        next_conflict = "]g",
-        take_head = "<leader>gh",
-        take_origin = "<leader>go",
-        take_both = "<leader>gb",
-    },
+  register_keymaps = true,
+  keymaps = {
+    prev_conflict = "[g",
+    next_conflict = "]g",
+    take_head = "<leader>gh",
+    take_origin = "<leader>go",
+    take_both = "<leader>gb",
+    populate_quickfix = "<leader>gq",
+  },
 }
 
 -- Parses git grep output (testable, can be called by tests)
 function M._parse_conflicts(output)
-    local conflicts = {}
-    for line in output:gmatch("[^\r\n]+") do
-        local file, lnum = line:match("^(.-):(%d+):<<<<<<<")
-        if file and lnum then
-            table.insert(conflicts, { file = file, lnum = tonumber(lnum) })
-        end
+  local local_conflicts = {}
+  for line in output:gmatch("[^\r\n]+") do
+    local file, lnum = line:match("^(.-):(%d+):<<<<<<<")
+    if file and lnum then
+      table.insert(local_conflicts, { file = file, lnum = tonumber(lnum) })
     end
-    return conflicts
+  end
+  return local_conflicts
 end
 
 -- Parse lines in a file for conflicts (helper for get_conflicts)
 function M.parse_conflicts(file, lines)
-    local res = {}
-    for i, line in ipairs(lines) do
-        if line:match("^<<<<<<<") then
-            table.insert(res, { file = file, lnum = i })
-        end
+  local res = {}
+  for i, line in ipairs(lines) do
+    if line:match("^<<<<<<<") then
+      table.insert(res, { file = file, lnum = i })
     end
-    return res
+  end
+  return res
 end
 
 -- Get all Git conflicts across tracked files
-local function get_conflicts()
-    local conflicts_list = {}
-    local files = {}
+function M._get_conflicts()
+  local conflicts_list = {}
+  local files = {}
+  local seen_files = {}
 
-    local handle = io.popen("git ls-files 2>nul")
-    if handle then
-        local output = handle:read("*a")
-        handle:close()
-        for file in output:gmatch("[^\r\n]+") do
-            table.insert(files, vim.fn.fnamemodify(file, ":p"))
-        end
+  local handle = io.popen("git ls-files 2>nul")
+  if handle then
+    local output = handle:read("*a")
+    handle:close()
+    for file in output:gmatch("[^\r\n]+") do
+      -- `git ls-files` shows one entry per index stage
+      -- merges/stash conflicts only get scanned once here.
+      if not seen_files[file] then
+        seen_files[file] = true
+        table.insert(files, vim.fn.fnamemodify(file, ":p"))
+      end
     end
+  end
 
-    for _, file in ipairs(files) do
-        local ok, lines = pcall(vim.fn.readfile, file)
-        if ok then
-            local file_conflicts = M.parse_conflicts(file, lines)
-            vim.list_extend(conflicts_list, file_conflicts)
-        end
+  for _, file in ipairs(files) do
+    local ok, lines = pcall(vim.fn.readfile, file)
+    if ok then
+      local file_conflicts = M.parse_conflicts(file, lines)
+      vim.list_extend(conflicts_list, file_conflicts)
     end
+  end
 
-    table.sort(conflicts_list, function(a, b)
-        if a.file == b.file then
-            return a.lnum < b.lnum
-        end
-        return a.file < b.file
-    end)
+  table.sort(conflicts_list, function(a, b)
+    if a.file == b.file then
+      return a.lnum < b.lnum
+    end
+    return a.file < b.file
+  end)
 
-    return conflicts_list
+  return conflicts_list
 end
 
 local function build_quickfix_entries(conflicts_list)
-    local entries = {}
-    for _, conflict in ipairs(conflicts_list) do
-        local bufnr = vim.fn.bufadd(conflict.file)
-        table.insert(entries, {
-            bufnr = bufnr,
-            filename = vim.fn.fnamemodify(conflict.file, ":."),
-            lnum = conflict.lnum,
-            col = 1,
-            text = "Merge conflict marker",
-        })
-    end
-    return entries
+  local entries = {}
+  for _, conflict in ipairs(conflicts_list) do
+    local bufnr = vim.fn.bufadd(conflict.file)
+    table.insert(entries, {
+      bufnr = bufnr,
+      filename = vim.fn.fnamemodify(conflict.file, ":."),
+      lnum = conflict.lnum,
+      col = 1,
+      text = "Merge conflict marker",
+    })
+  end
+  return entries
 end
 
 -- Jump to next conflict
 local function navigate_conflict(direction)
-    conflicts = M._get_conflicts()
+  conflicts = M._get_conflicts()
 
-    if #conflicts == 0 then
-        print("No conflicts found ✅")
-        return
-    end
+  if #conflicts == 0 then
+    print("No conflicts found ✅")
+    return
+  end
 
-    current_index = current_index + direction * 1
-    if current_index > #conflicts then
-        current_index = 1
-    elseif current_index < 1 then
-        current_index = #conflicts
-    end
+  current_index = current_index + direction * 1
+  if current_index > #conflicts then
+    current_index = 1
+  elseif current_index < 1 then
+    current_index = #conflicts
+  end
 
-    local conflict = conflicts[current_index]
-    vim.cmd("edit " .. conflict.file)
-    vim.api.nvim_win_set_cursor(0, { conflict.lnum, 0 })
+  local conflict = conflicts[current_index]
+  vim.cmd("edit " .. conflict.file)
+  vim.api.nvim_win_set_cursor(0, { conflict.lnum, 0 })
 end
 
 function M.populate_quickfix()
-    local conflicts_list = M._get_conflicts()
-    if #conflicts_list == 0 then
-        vim.fn.setqflist({}, "r")
-        print("No conflicts found ✅")
-        return
-    end
+  local conflicts_list = M._get_conflicts()
+  if #conflicts_list == 0 then
+    vim.fn.setqflist({}, "r")
+    print("No conflicts found ✅")
+    return
+  end
 
-    local entries = build_quickfix_entries(conflicts_list)
-    vim.fn.setqflist(entries, "r")
-    vim.cmd("copen")
+  local entries = build_quickfix_entries(conflicts_list)
+  vim.fn.setqflist(entries, "r")
+  vim.cmd("copen")
 end
 
 -- Jump to next conflict
 function M.prev_conflict()
-    navigate_conflict(-1)
+  navigate_conflict(-1)
 end
 
 -- Jump to next conflict
 function M.next_conflict()
-    navigate_conflict(1)
+  navigate_conflict(1)
 end
 
 -- Extract conflict block (HEAD, ORIGIN)
 local function get_conflict_block(bufnr, start_line)
-    local lines = vim.api.nvim_buf_get_lines(bufnr, start_line - 1, -1, false)
-    local head_lines, origin_lines = {}, {}
-    local mode = "head"
+  local lines = vim.api.nvim_buf_get_lines(bufnr, start_line - 1, -1, false)
+  local head_lines, origin_lines = {}, {}
+  local mode = "head"
 
-    local consumed = 0
-    for _, line in ipairs(lines) do
-        consumed = consumed + 1
-        if line:match("^<<<<<<<") then
-            mode = "head"
-        elseif line:match("^=======") then
-            mode = "origin"
-        elseif line:match("^>>>>>>>") then
-            break
-        else
-            if mode == "head" then
-                table.insert(head_lines, line)
-            else
-                table.insert(origin_lines, line)
-            end
-        end
+  local consumed = 0
+  for _, line in ipairs(lines) do
+    consumed = consumed + 1
+    if line:match("^<<<<<<<") then
+      mode = "head"
+    elseif line:match("^=======") then
+      mode = "origin"
+    elseif line:match("^>>>>>>>") then
+      break
+    else
+      if mode == "head" then
+        table.insert(head_lines, line)
+      else
+        table.insert(origin_lines, line)
+      end
     end
+  end
 
-    return head_lines, origin_lines, consumed
+  return head_lines, origin_lines, consumed
 end
 
 -- Replace conflict with resolution
 local function apply_resolution(mode)
-    local bufnr = vim.api.nvim_get_current_buf()
-    local cursor = vim.api.nvim_win_get_cursor(0)
-    local start_line = cursor[1]
+  local bufnr = vim.api.nvim_get_current_buf()
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  local start_line = cursor[1]
 
-    local head_lines, origin_lines, consumed =
-        get_conflict_block(bufnr, start_line)
+  local head_lines, origin_lines, consumed =
+      get_conflict_block(bufnr, start_line)
 
-    local replacement = {}
-    if mode == "head" then
-        replacement = head_lines
-    elseif mode == "origin" then
-        replacement = origin_lines
-    elseif mode == "both" then
-        vim.list_extend(replacement, head_lines)
-        vim.list_extend(replacement, origin_lines)
-    end
+  local replacement = {}
+  if mode == "head" then
+    replacement = head_lines
+  elseif mode == "origin" then
+    replacement = origin_lines
+  elseif mode == "both" then
+    vim.list_extend(replacement, head_lines)
+    vim.list_extend(replacement, origin_lines)
+  end
 
-    vim.api.nvim_buf_set_lines(
-        bufnr,
-        start_line - 1,
-        start_line - 1 + consumed,
-        false,
-        replacement
-    )
+  vim.api.nvim_buf_set_lines(
+    bufnr,
+    start_line - 1,
+    start_line - 1 + consumed,
+    false,
+    replacement
+  )
 end
 
 function M.take_head()
-    apply_resolution("head")
+  apply_resolution("head")
 end
+
 function M.take_origin()
-    apply_resolution("origin")
+  apply_resolution("origin")
 end
+
 function M.take_both()
-    apply_resolution("both")
+  apply_resolution("both")
 end
 
 function M._register_keymaps(config)
-    vim.keymap.set(
-        "n",
-        config.keymaps.prev_conflict,
-        M.prev_conflict,
-        { desc = "Previous Git conflict" }
-    )
-    vim.keymap.set(
-        "n",
-        config.keymaps.next_conflict,
-        M.next_conflict,
-        { desc = "Next Git conflict" }
-    )
-    vim.keymap.set(
-        "n",
-        config.keymaps.take_head,
-        M.take_head,
-        { desc = "Take HEAD in conflict" }
-    )
-    vim.keymap.set(
-        "n",
-        config.keymaps.take_origin,
-        M.take_origin,
-        { desc = "Take ORIGIN in conflict" }
-    )
-    vim.keymap.set(
-        "n",
-        config.keymaps.take_both,
-        M.take_both,
-        { desc = "Take BOTH in conflict" }
-    )
+  vim.keymap.set(
+    "n",
+    config.keymaps.prev_conflict,
+    M.prev_conflict,
+    { desc = "Previous Git conflict" }
+  )
+  vim.keymap.set(
+    "n",
+    config.keymaps.next_conflict,
+    M.next_conflict,
+    { desc = "Next Git conflict" }
+  )
+  vim.keymap.set(
+    "n",
+    config.keymaps.take_head,
+    M.take_head,
+    { desc = "Take HEAD in conflict" }
+  )
+  vim.keymap.set(
+    "n",
+    config.keymaps.take_origin,
+    M.take_origin,
+    { desc = "Take ORIGIN in conflict" }
+  )
+  vim.keymap.set(
+    "n",
+    config.keymaps.take_both,
+    M.take_both,
+    { desc = "Take BOTH in conflict" }
+  )
 end
 
 local config = vim.deepcopy(defaultConfig)
 
 function M.setup(user_config)
-    if user_config then
-        config = vim.tbl_deep_extend("force", config, user_config)
-    end
+  if user_config then
+    config = vim.tbl_deep_extend("force", config, user_config)
+  end
 
-    if config.register_keymaps then
-        M._register_keymaps(config)
-    end
+  if config.register_keymaps then
+    M._register_keymaps(config)
+  end
 
-    vim.api.nvim_create_user_command(
-        "HeadhunterPrevious",
-        M.prev_conflict,
-        { desc = "Go to previous Git conflict" }
-    )
-    vim.api.nvim_create_user_command(
-        "HeadhunterNext",
-        M.next_conflict,
-        { desc = "Go to next Git conflict" }
-    )
+  vim.api.nvim_create_user_command(
+    "HeadhunterPrevious",
+    M.prev_conflict,
+    { desc = "Go to previous Git conflict" }
+  )
+  vim.api.nvim_create_user_command(
+    "HeadhunterNext",
+    M.next_conflict,
+    { desc = "Go to next Git conflict" }
+  )
 
-    vim.api.nvim_create_user_command("HeadhunterTakeHead", M.take_head, {})
-    vim.api.nvim_create_user_command("HeadhunterTakeOrigin", M.take_origin, {})
-    vim.api.nvim_create_user_command("HeadhunterTakeBoth", M.take_both, {})
+  vim.api.nvim_create_user_command(
+    "HeadhunterTakeHead",
+    M.take_head,
+    { desc = "Take changes from HEAD" }
+  )
+  vim.api.nvim_create_user_command(
+    "HeadhunterTakeOrigin",
+    M.take_origin,
+    { desc = "Take changes from origin" }
+  )
+  vim.api.nvim_create_user_command(
+    "HeadhunterTakeBoth",
+    M.take_both,
+    { desc = "Take both changes" }
+  )
 
-    vim.api.nvim_create_user_command(
-        "HeadhunterQuickfix",
-        M.populate_quickfix,
-        { desc = "List Git conflicts in quickfix" }
-    )
+  vim.api.nvim_create_user_command(
+    "HeadhunterQuickfix",
+    M.populate_quickfix,
+    { desc = "List Git conflicts in quickfix" }
+  )
 
-    vim.api.nvim_create_user_command("HeadhunterReload", function()
-        package.loaded["headhunter"] = nil
-        require("headhunter").setup()
-    end, {})
+  vim.api.nvim_create_user_command("HeadhunterReload", function()
+    package.loaded["headhunter"] = nil
+    require("headhunter").setup()
+  end, {})
 end
 
-M._get_conflicts = get_conflicts
 M._get_conflicts_mock = M._parse_conflicts
 
 return M

--- a/lua/headhunter/init.lua
+++ b/lua/headhunter/init.lua
@@ -18,7 +18,7 @@ local defaultConfig = {
 function M._parse_conflicts(output)
     local conflicts = {}
     for line in output:gmatch("[^\r\n]+") do
-        local file, lnum = line:match("^(.-):(%d+):<<<<<<< HEAD")
+        local file, lnum = line:match("^(.-):(%d+):<<<<<<<")
         if file and lnum then
             table.insert(conflicts, { file = file, lnum = tonumber(lnum) })
         end
@@ -30,7 +30,7 @@ end
 function M.parse_conflicts(file, lines)
     local res = {}
     for i, line in ipairs(lines) do
-        if line:match("^<<<<<<< HEAD") then
+        if line:match("^<<<<<<<") then
             table.insert(res, { file = file, lnum = i })
         end
     end
@@ -109,7 +109,7 @@ local function get_conflict_block(bufnr, start_line)
     local consumed = 0
     for _, line in ipairs(lines) do
         consumed = consumed + 1
-        if line:match("^<<<<<<< HEAD") then
+        if line:match("^<<<<<<<") then
             mode = "head"
         elseif line:match("^=======") then
             mode = "origin"

--- a/lua/headhunter/init.lua
+++ b/lua/headhunter/init.lua
@@ -4,285 +4,294 @@ local conflicts = {}
 local current_index = 0
 
 local defaultConfig = {
-  register_keymaps = true,
-  keymaps = {
-    prev_conflict = "[g",
-    next_conflict = "]g",
-    take_head = "<leader>gh",
-    take_origin = "<leader>go",
-    take_both = "<leader>gb",
-    populate_quickfix = "<leader>gq",
-  },
+    register_keymaps = true,
+    keymaps = {
+        prev_conflict = "[g",
+        next_conflict = "]g",
+        take_head = "<leader>gh",
+        take_origin = "<leader>go",
+        take_both = "<leader>gb",
+        populate_quickfix = "<leader>gq",
+    },
 }
 
 -- Parses git grep output (testable, can be called by tests)
 function M._parse_conflicts(output)
-  local local_conflicts = {}
-  for line in output:gmatch("[^\r\n]+") do
-    local file, lnum = line:match("^(.-):(%d+):<<<<<<<")
-    if file and lnum then
-      table.insert(local_conflicts, { file = file, lnum = tonumber(lnum) })
+    local local_conflicts = {}
+    for line in output:gmatch("[^\r\n]+") do
+        local file, lnum = line:match("^(.-):(%d+):<<<<<<<")
+        if file and lnum then
+            table.insert(
+                local_conflicts,
+                { file = file, lnum = tonumber(lnum) }
+            )
+        end
     end
-  end
-  return local_conflicts
+    return local_conflicts
 end
 
 -- Parse lines in a file for conflicts (helper for get_conflicts)
 function M.parse_conflicts(file, lines)
-  local res = {}
-  for i, line in ipairs(lines) do
-    if line:match("^<<<<<<<") then
-      table.insert(res, { file = file, lnum = i })
+    local res = {}
+    for i, line in ipairs(lines) do
+        if line:match("^<<<<<<<") then
+            table.insert(res, { file = file, lnum = i })
+        end
     end
-  end
-  return res
+    return res
 end
 
 -- Get all Git conflicts across tracked files
 function M._get_conflicts()
-  local conflicts_list = {}
-  local files = {}
-  local seen_files = {}
+    local conflicts_list = {}
+    local files = {}
+    local seen_files = {}
 
-  local handle = io.popen("git ls-files 2>nul")
-  if handle then
-    local output = handle:read("*a")
-    handle:close()
-    for file in output:gmatch("[^\r\n]+") do
-      -- `git ls-files` shows one entry per index stage
-      -- merges/stash conflicts only get scanned once here.
-      if not seen_files[file] then
-        seen_files[file] = true
-        table.insert(files, vim.fn.fnamemodify(file, ":p"))
-      end
+    local handle = io.popen("git ls-files 2>nul")
+    if handle then
+        local output = handle:read("*a")
+        handle:close()
+        for file in output:gmatch("[^\r\n]+") do
+            -- `git ls-files` shows one entry per index stage
+            -- merges/stash conflicts only get scanned once here.
+            if not seen_files[file] then
+                seen_files[file] = true
+                table.insert(files, vim.fn.fnamemodify(file, ":p"))
+            end
+        end
     end
-  end
 
-  for _, file in ipairs(files) do
-    local ok, lines = pcall(vim.fn.readfile, file)
-    if ok then
-      local file_conflicts = M.parse_conflicts(file, lines)
-      vim.list_extend(conflicts_list, file_conflicts)
+    for _, file in ipairs(files) do
+        local ok, lines = pcall(vim.fn.readfile, file)
+        if ok then
+            local file_conflicts = M.parse_conflicts(file, lines)
+            vim.list_extend(conflicts_list, file_conflicts)
+        end
     end
-  end
 
-  table.sort(conflicts_list, function(a, b)
-    if a.file == b.file then
-      return a.lnum < b.lnum
-    end
-    return a.file < b.file
-  end)
+    table.sort(conflicts_list, function(a, b)
+        if a.file == b.file then
+            return a.lnum < b.lnum
+        end
+        return a.file < b.file
+    end)
 
-  return conflicts_list
+    return conflicts_list
 end
 
 local function build_quickfix_entries(conflicts_list)
-  local entries = {}
-  for _, conflict in ipairs(conflicts_list) do
-    local bufnr = vim.fn.bufadd(conflict.file)
-    table.insert(entries, {
-      bufnr = bufnr,
-      filename = vim.fn.fnamemodify(conflict.file, ":."),
-      lnum = conflict.lnum,
-      col = 1,
-      text = "Merge conflict marker",
-    })
-  end
-  return entries
+    local entries = {}
+    for _, conflict in ipairs(conflicts_list) do
+        local bufnr = vim.fn.bufadd(conflict.file)
+        table.insert(entries, {
+            bufnr = bufnr,
+            filename = vim.fn.fnamemodify(conflict.file, ":."),
+            lnum = conflict.lnum,
+            col = 1,
+            text = "Merge conflict marker",
+        })
+    end
+    return entries
 end
 
 -- Jump to next conflict
 local function navigate_conflict(direction)
-  conflicts = M._get_conflicts()
+    conflicts = M._get_conflicts()
 
-  if #conflicts == 0 then
-    print("No conflicts found ✅")
-    return
-  end
+    if #conflicts == 0 then
+        print("No conflicts found ✅")
+        return
+    end
 
-  current_index = current_index + direction * 1
-  if current_index > #conflicts then
-    current_index = 1
-  elseif current_index < 1 then
-    current_index = #conflicts
-  end
+    current_index = current_index + direction * 1
+    if current_index > #conflicts then
+        current_index = 1
+    elseif current_index < 1 then
+        current_index = #conflicts
+    end
 
-  local conflict = conflicts[current_index]
-  vim.cmd("edit " .. conflict.file)
-  vim.api.nvim_win_set_cursor(0, { conflict.lnum, 0 })
+    local conflict = conflicts[current_index]
+    vim.cmd("edit " .. conflict.file)
+    vim.api.nvim_win_set_cursor(0, { conflict.lnum, 0 })
 end
 
 function M.populate_quickfix()
-  local conflicts_list = M._get_conflicts()
-  if #conflicts_list == 0 then
-    vim.fn.setqflist({}, "r")
-    print("No conflicts found ✅")
-    return
-  end
+    local conflicts_list = M._get_conflicts()
+    if #conflicts_list == 0 then
+        vim.fn.setqflist({}, "r")
+        print("No conflicts found ✅")
+        return
+    end
 
-  local entries = build_quickfix_entries(conflicts_list)
-  vim.fn.setqflist(entries, "r")
-  vim.cmd("copen")
+    local entries = build_quickfix_entries(conflicts_list)
+    vim.fn.setqflist(entries, "r")
+    vim.cmd("copen")
 end
 
 -- Jump to next conflict
 function M.prev_conflict()
-  navigate_conflict(-1)
+    navigate_conflict(-1)
 end
 
 -- Jump to next conflict
 function M.next_conflict()
-  navigate_conflict(1)
+    navigate_conflict(1)
 end
 
 -- Extract conflict block (HEAD, ORIGIN)
 local function get_conflict_block(bufnr, start_line)
-  local lines = vim.api.nvim_buf_get_lines(bufnr, start_line - 1, -1, false)
-  local head_lines, origin_lines = {}, {}
-  local mode = "head"
+    local lines = vim.api.nvim_buf_get_lines(bufnr, start_line - 1, -1, false)
+    local head_lines, origin_lines = {}, {}
+    local mode = "head"
 
-  local consumed = 0
-  for _, line in ipairs(lines) do
-    consumed = consumed + 1
-    if line:match("^<<<<<<<") then
-      mode = "head"
-    elseif line:match("^=======") then
-      mode = "origin"
-    elseif line:match("^>>>>>>>") then
-      break
-    else
-      if mode == "head" then
-        table.insert(head_lines, line)
-      else
-        table.insert(origin_lines, line)
-      end
+    local consumed = 0
+    for _, line in ipairs(lines) do
+        consumed = consumed + 1
+        if line:match("^<<<<<<<") then
+            mode = "head"
+        elseif line:match("^=======") then
+            mode = "origin"
+        elseif line:match("^>>>>>>>") then
+            break
+        else
+            if mode == "head" then
+                table.insert(head_lines, line)
+            else
+                table.insert(origin_lines, line)
+            end
+        end
     end
-  end
 
-  return head_lines, origin_lines, consumed
+    return head_lines, origin_lines, consumed
 end
 
 -- Replace conflict with resolution
 local function apply_resolution(mode)
-  local bufnr = vim.api.nvim_get_current_buf()
-  local cursor = vim.api.nvim_win_get_cursor(0)
-  local start_line = cursor[1]
+    local bufnr = vim.api.nvim_get_current_buf()
+    local cursor = vim.api.nvim_win_get_cursor(0)
+    local start_line = cursor[1]
 
-  local head_lines, origin_lines, consumed =
-      get_conflict_block(bufnr, start_line)
+    local head_lines, origin_lines, consumed =
+        get_conflict_block(bufnr, start_line)
 
-  local replacement = {}
-  if mode == "head" then
-    replacement = head_lines
-  elseif mode == "origin" then
-    replacement = origin_lines
-  elseif mode == "both" then
-    vim.list_extend(replacement, head_lines)
-    vim.list_extend(replacement, origin_lines)
-  end
+    local replacement = {}
+    if mode == "head" then
+        replacement = head_lines
+    elseif mode == "origin" then
+        replacement = origin_lines
+    elseif mode == "both" then
+        vim.list_extend(replacement, head_lines)
+        vim.list_extend(replacement, origin_lines)
+    end
 
-  vim.api.nvim_buf_set_lines(
-    bufnr,
-    start_line - 1,
-    start_line - 1 + consumed,
-    false,
-    replacement
-  )
+    vim.api.nvim_buf_set_lines(
+        bufnr,
+        start_line - 1,
+        start_line - 1 + consumed,
+        false,
+        replacement
+    )
 end
 
 function M.take_head()
-  apply_resolution("head")
+    apply_resolution("head")
 end
 
 function M.take_origin()
-  apply_resolution("origin")
+    apply_resolution("origin")
 end
 
 function M.take_both()
-  apply_resolution("both")
+    apply_resolution("both")
 end
 
 function M._register_keymaps(config)
-  vim.keymap.set(
-    "n",
-    config.keymaps.prev_conflict,
-    M.prev_conflict,
-    { desc = "Previous Git conflict" }
-  )
-  vim.keymap.set(
-    "n",
-    config.keymaps.next_conflict,
-    M.next_conflict,
-    { desc = "Next Git conflict" }
-  )
-  vim.keymap.set(
-    "n",
-    config.keymaps.take_head,
-    M.take_head,
-    { desc = "Take HEAD in conflict" }
-  )
-  vim.keymap.set(
-    "n",
-    config.keymaps.take_origin,
-    M.take_origin,
-    { desc = "Take ORIGIN in conflict" }
-  )
-  vim.keymap.set(
-    "n",
-    config.keymaps.take_both,
-    M.take_both,
-    { desc = "Take BOTH in conflict" }
-  )
+    vim.keymap.set(
+        "n",
+        config.keymaps.prev_conflict,
+        M.prev_conflict,
+        { desc = "Previous Git conflict" }
+    )
+    vim.keymap.set(
+        "n",
+        config.keymaps.next_conflict,
+        M.next_conflict,
+        { desc = "Next Git conflict" }
+    )
+    vim.keymap.set(
+        "n",
+        config.keymaps.take_head,
+        M.take_head,
+        { desc = "Take HEAD in conflict" }
+    )
+    vim.keymap.set(
+        "n",
+        config.keymaps.take_origin,
+        M.take_origin,
+        { desc = "Take ORIGIN in conflict" }
+    )
+    vim.keymap.set(
+        "n",
+        config.keymaps.take_both,
+        M.take_both,
+        { desc = "Take BOTH in conflict" }
+    )
+    vim.keymap.set(
+        "n",
+        config.keymaps.populate_quickfix,
+        M.populate_quickfix,
+        { desc = "List Git conflicts in quickfix" }
+    )
 end
 
 local config = vim.deepcopy(defaultConfig)
 
 function M.setup(user_config)
-  if user_config then
-    config = vim.tbl_deep_extend("force", config, user_config)
-  end
+    if user_config then
+        config = vim.tbl_deep_extend("force", config, user_config)
+    end
 
-  if config.register_keymaps then
-    M._register_keymaps(config)
-  end
+    if config.register_keymaps then
+        M._register_keymaps(config)
+    end
 
-  vim.api.nvim_create_user_command(
-    "HeadhunterPrevious",
-    M.prev_conflict,
-    { desc = "Go to previous Git conflict" }
-  )
-  vim.api.nvim_create_user_command(
-    "HeadhunterNext",
-    M.next_conflict,
-    { desc = "Go to next Git conflict" }
-  )
+    vim.api.nvim_create_user_command(
+        "HeadhunterPrevious",
+        M.prev_conflict,
+        { desc = "Go to previous Git conflict" }
+    )
+    vim.api.nvim_create_user_command(
+        "HeadhunterNext",
+        M.next_conflict,
+        { desc = "Go to next Git conflict" }
+    )
 
-  vim.api.nvim_create_user_command(
-    "HeadhunterTakeHead",
-    M.take_head,
-    { desc = "Take changes from HEAD" }
-  )
-  vim.api.nvim_create_user_command(
-    "HeadhunterTakeOrigin",
-    M.take_origin,
-    { desc = "Take changes from origin" }
-  )
-  vim.api.nvim_create_user_command(
-    "HeadhunterTakeBoth",
-    M.take_both,
-    { desc = "Take both changes" }
-  )
+    vim.api.nvim_create_user_command(
+        "HeadhunterTakeHead",
+        M.take_head,
+        { desc = "Take changes from HEAD" }
+    )
+    vim.api.nvim_create_user_command(
+        "HeadhunterTakeOrigin",
+        M.take_origin,
+        { desc = "Take changes from origin" }
+    )
+    vim.api.nvim_create_user_command(
+        "HeadhunterTakeBoth",
+        M.take_both,
+        { desc = "Take both changes" }
+    )
 
-  vim.api.nvim_create_user_command(
-    "HeadhunterQuickfix",
-    M.populate_quickfix,
-    { desc = "List Git conflicts in quickfix" }
-  )
+    vim.api.nvim_create_user_command(
+        "HeadhunterQuickfix",
+        M.populate_quickfix,
+        { desc = "List Git conflicts in quickfix" }
+    )
 
-  vim.api.nvim_create_user_command("HeadhunterReload", function()
-    package.loaded["headhunter"] = nil
-    require("headhunter").setup()
-  end, {})
+    vim.api.nvim_create_user_command("HeadhunterReload", function()
+        package.loaded["headhunter"] = nil
+        require("headhunter").setup()
+    end, {})
 end
 
 M._get_conflicts_mock = M._parse_conflicts

--- a/lua/tests/conflict_resolution_spec.lua
+++ b/lua/tests/conflict_resolution_spec.lua
@@ -55,4 +55,20 @@ describe("headhunter conflict resolution", function()
         local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
         assert.are.same({ "my change", "their change" }, lines)
     end)
+
+    it("handles stash-style conflict markers", function()
+        vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, {
+            "<<<<<<< Updated upstream",
+            "upstream change",
+            "=======",
+            "stashed change",
+            ">>>>>>> Stashed changes",
+        })
+        vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+        headhunter.take_head()
+
+        local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+        assert.are.same({ "upstream change" }, lines)
+    end)
 end)

--- a/lua/tests/headhunter_spec.lua
+++ b/lua/tests/headhunter_spec.lua
@@ -62,4 +62,16 @@ file2.txt:14:>>>>>>> branch
         assert.are.equal("file2.txt", conflicts[2].file)
         assert.are.equal(10, conflicts[2].lnum)
     end)
+
+    it("parses stash-style conflict markers", function()
+        local sample = [[
+file1.txt:3:<<<<<<< Updated upstream
+file1.txt:5:=======
+file1.txt:7:>>>>>>> Stashed changes
+]]
+        local conflicts = headhunter._get_conflicts_mock(sample)
+        assert.are.equal(1, #conflicts)
+        assert.are.equal("file1.txt", conflicts[1].file)
+        assert.are.equal(3, conflicts[1].lnum)
+    end)
 end)

--- a/lua/tests/quickfix_spec.lua
+++ b/lua/tests/quickfix_spec.lua
@@ -25,8 +25,9 @@ describe("headhunter quickfix integration", function()
 
         local items = vim.fn.getqflist()
         assert.are.equal(1, #items)
-        local bufname = vim.fn.fnamemodify(vim.fn.bufname(items[1].bufnr), ":.")
-        assert.are.equal(vim.fn.fnamemodify(file, ":."), bufname)
+        local listed_path = items[1].filename
+            or vim.fn.fnamemodify(vim.fn.bufname(items[1].bufnr), ":.")
+        assert.are.equal(vim.fn.fnamemodify(file, ":."), listed_path)
         assert.are.equal(12, items[1].lnum)
         assert.are.equal("Merge conflict marker", items[1].text)
     end)
@@ -35,10 +36,12 @@ describe("headhunter quickfix integration", function()
         headhunter._get_conflicts = function()
             return {}
         end
-        vim.fn.setqflist({ {
-            filename = "dummy.lua",
-            lnum = 1,
-        } })
+        vim.fn.setqflist({
+            {
+                filename = "dummy.lua",
+                lnum = 1,
+            },
+        })
 
         headhunter.populate_quickfix()
 

--- a/lua/tests/quickfix_spec.lua
+++ b/lua/tests/quickfix_spec.lua
@@ -1,0 +1,48 @@
+local headhunter = require("headhunter")
+
+describe("headhunter quickfix integration", function()
+    local original_get_conflicts
+
+    before_each(function()
+        original_get_conflicts = headhunter._get_conflicts
+        vim.fn.setqflist({})
+    end)
+
+    after_each(function()
+        headhunter._get_conflicts = original_get_conflicts
+        vim.fn.setqflist({})
+    end)
+
+    it("populates quickfix with conflicts", function()
+        local file = vim.fn.fnamemodify("lua/headhunter/init.lua", ":p")
+        headhunter._get_conflicts = function()
+            return {
+                { file = file, lnum = 12 },
+            }
+        end
+
+        headhunter.populate_quickfix()
+
+        local items = vim.fn.getqflist()
+        assert.are.equal(1, #items)
+        local bufname = vim.fn.fnamemodify(vim.fn.bufname(items[1].bufnr), ":.")
+        assert.are.equal(vim.fn.fnamemodify(file, ":."), bufname)
+        assert.are.equal(12, items[1].lnum)
+        assert.are.equal("Merge conflict marker", items[1].text)
+    end)
+
+    it("clears quickfix when no conflicts", function()
+        headhunter._get_conflicts = function()
+            return {}
+        end
+        vim.fn.setqflist({ {
+            filename = "dummy.lua",
+            lnum = 1,
+        } })
+
+        headhunter.populate_quickfix()
+
+        local items = vim.fn.getqflist()
+        assert.are.equal(0, #items)
+    end)
+end)


### PR DESCRIPTION
  - Expose conflict discovery via `M._get_conflicts` and reuse it to populate the quickfix list
  - Add `:HeadhunterQuickfix` plus default `<leader>gq` binding and extend the test suite for parser/quickfix behaviour
  - Check against duplicate git-ls entries