### PR TITLE
fix: Discard `git ls-files` output

### DIFF
--- a/lua/headhunter/init.lua
+++ b/lua/headhunter/init.lua
@@ -42,7 +42,7 @@ local function get_conflicts()
     local conflicts_list = {}
     local files = {}
 
-    local handle = io.popen("git ls-files 2>nul")
+    local handle = io.popen("git ls-files 2>/dev/null")
     if handle then
         local output = handle:read("*a")
         handle:close()


### PR DESCRIPTION
Current version creates a file named `nul` in my current working directory. I think the intention is to discard this output instead.